### PR TITLE
Release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is loosely based on Keep a Changelog, and this project follows Semant
 
 ## [Unreleased]
 
+## [0.1.2] - 2026-02-10
+
+### Changed
+- Bump `criterion` dev-dependency from 0.8.1 to 0.8.2.
+- Bump `proptest` dev-dependency from 1.9.0 to 1.10.0.
+
 ## [0.1.1] - 2026-01-27
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -664,7 +664,7 @@ checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "wabi_tree"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "criterion",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "wabi_tree"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 rust-version = "1.87"
 


### PR DESCRIPTION
## Summary
  - Bump criterion from 0.8.1 to 0.8.2
  - Bump proptest from 1.9.0 to 1.10.0
  - Prepare v0.1.2 release (version bump and CHANGELOG update)